### PR TITLE
always return a promise; return last successful cache on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ app.get('/css/app.css', lessExpress('./public/stylesheets/app.less', lessOptions
 
 - `cache`: TTL in milliseconds that compilation results will be cached. When `true` is passed the cache will keep the initial compilation result infinitely. By default the middleware uses infinite caching in production. If you want to disable this pass `false`.
 - `precompile`: Tell the middleware to precompile the stylesheet on application startup. This is happening per default in production and can be disabled by passing `false`. If you explicitly set `cache` to `false` this will do nothing.
+- `stale`: If `true` then the middleware will return a stale cache of the stylesheet, if available, when a compilation error is encountered. This is `false` by default. If you explicitly set `cache` to `false` this will do nothing.
+- `passThru`: If `true` then the middleware will not send the response and instead will assign the resulting stylesheet to `res.locals.lessCss` using the given location and call the next middleware. i.e
+```js
+lessExpress.options({passThru: true});
+app.get('/css/app.css', lessExpress('./public/stylesheets/app.less'), function (req, res, next) {
+    var css = res.locals.lessCss['./public/stylesheets/app.less'];
+});
+```
+This is useful for extra processing you may want to apply after compilation, but before sending the response. This is `false` by default.
 
 You can also set global configuration options that will be applied to all calls by using `#lessOptions` and `#options`:
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ function lessExpress(location, lessOptions, options){
 		paths: [_.initial(location.split('/')).join('/')]
 	}, globalLessOptions, lessOptions);
 	var localOptions = _.extend({}, globalOptions, options);
-	var localCache = localOptions.cache === false ? null
+	var localCache = localOptions.cache === false
+		? null
 		: (localOptions.cache || process.env.NODE_ENV === 'production')
 			? new LRU({
 				length: function(){ return 1; }
@@ -42,24 +43,23 @@ function lessExpress(location, lessOptions, options){
 			result = localCache.get(location);
 			if (result){
 				return result.then(function(css){
-					res.set('Content-Type', 'text/css');
-					res.send(css);
+					res.set('Content-Type', 'text/css').send(css);
 				})
 				.catch(next);
 			}
 		}
 		result = render(location, localLessOptions).then(function(css){
+			res.set('Content-Type', 'text/css').send(css);
 			if (localCache) localCache.set(location, result);
-			res.set('Content-Type', 'text/css');
-			res.send(css);
 			return css;
 		})
-		.catch(function (err) {
+		.catch(function(err){
 			var lastBuild = localCache && localCache.get(location);
-			if (lastBuild) return lastBuild.then(function (css) {
-				res.set('Content-Type', 'text/css').send(css);
-			});
-			else throw err;
+			if (lastBuild){
+				return lastBuild.then(function(css){
+					res.set('Content-Type', 'text/css').send(css);
+				});
+			} else throw err;
 		})
 		.catch(next);
 		return result;

--- a/index.js
+++ b/index.js
@@ -17,8 +17,7 @@ function lessExpress(location, lessOptions, options){
 		paths: [_.initial(location.split('/')).join('/')]
 	}, globalLessOptions, lessOptions);
 	var localOptions = _.extend({}, globalOptions, options);
-	var localStale = localOptions.cache && localOptions.stale
-		, localStaleCache = {};
+	var localStaleCache = {};
 	var localCache = localOptions.cache === false
 		? null
 		: (localOptions.cache || process.env.NODE_ENV === 'production')
@@ -64,7 +63,7 @@ function lessExpress(location, lessOptions, options){
 			if (localCache) localCache.set(location, result);
 			return css;
 		})
-		.catch(localStale ? function(err){
+		.catch(localOptions.cache && localOptions.stale ? function(err){
 			var lastBuild = localCache && (localCache.get(location) || localStaleCache[location]);
 			if (lastBuild){
 				return lastBuild.then(sendOrNext);

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -15,6 +15,9 @@ app.get('/import.css', lessExpress('./test/fixtures/import.less'));
 app.get('/404.css', lessExpress('./test/fixtures/404.less'));
 app.get('/broken.css', lessExpress('./test/fixtures/broken.less'));
 app.get('/stale.css', lessExpress('./test/fixtures/stale.less', null, {cache: 1, stale: true}));
+app.get('/pass-thru.css', lessExpress('./test/fixtures/simple.less', null, {passThru: true}), function(req, res) {
+	res.status(202).send(res.locals.lessCss['./test/fixtures/simple.less']);
+});
 
 app.use(function(err, req, res, next){ //eslint-disable-line no-unused-vars
 	res.status(err.status || 500);

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -14,6 +14,7 @@ app.get('/minified.css', lessExpress('./test/fixtures/minified.less', {plugins: 
 app.get('/import.css', lessExpress('./test/fixtures/import.less'));
 app.get('/404.css', lessExpress('./test/fixtures/404.less'));
 app.get('/broken.css', lessExpress('./test/fixtures/broken.less'));
+app.get('/stale.css', lessExpress('./test/fixtures/stale.less', null, {cache: 1, stale: true}));
 
 app.use(function(err, req, res, next){ //eslint-disable-line no-unused-vars
 	res.status(err.status || 500);

--- a/test/test.js
+++ b/test/test.js
@@ -117,5 +117,12 @@ describe('less-express', function(){
 						.end(done);
 				});
 		});
+		it('passes css to next middleware with passThru option', function(done){
+			request(app)
+				.get('/pass-thru.css')
+				.expect(202)
+				.expect(expectMatch)
+				.end(done);
+		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -58,9 +58,6 @@ describe('less-express', function(){
 	});
 	describe('middleware', function(){
 		var expectMatch = /#ff00ff/;
-		after(function(done){
-			fs.unlink('./test/fixtures/stale.less', done);
-		});
 
 		it('compiles less into css when the file is found', function(done){
 			request(app)
@@ -114,7 +111,9 @@ describe('less-express', function(){
 						.get(endpoint)
 						.expect(200)
 						.expect(expectMatch)
-						.end(done);
+						.end(function(){
+							fs.unlink('./test/fixtures/stale.less', done);
+						});
 				});
 		});
 		it('passes css to next middleware with passThru option', function(done){


### PR DESCRIPTION
A promise is returned when caching is enabled. This makes it so a promise is always returned regardless of caching for more consistent handling of results.

Also if there is an error during compilation and a current valid cache is available that will be returned instead of failing